### PR TITLE
Fix problems with the new CelebA class that were discovered during testing

### DIFF
--- a/bolts/data/datasets/vision/celeba.py
+++ b/bolts/data/datasets/vision/celeba.py
@@ -64,8 +64,8 @@ class Celeba(VisionDataset):
         self.metadata = data_tup.x
 
         self.x = self.metadata["filename"].to_numpy(copy=True)
-        self.s = torch.as_tensor(data_tup.s, dtype=torch.int32)
-        self.y = torch.as_tensor(data_tup.y, dtype=torch.int32)
+        self.s = torch.as_tensor(data_tup.s.to_numpy(), dtype=torch.int32).view(-1)
+        self.y = torch.as_tensor(data_tup.y.to_numpy(), dtype=torch.int32).view(-1)
 
         self._il_backend: ImageLoadingBackend = infer_il_backend(self.transform)
 
@@ -89,7 +89,7 @@ class Celeba(VisionDataset):
                 path=str(self.base / filename),
                 quiet=False,
                 md5=md5,
-                postprocess=gdown.extractall,
+                postprocess=gdown.extractall if filename.endswith(".zip") else None,
             )
 
         assert self._check_unzipped()


### PR DESCRIPTION
Follow-up to #17.

Downloading looks like this:

```
Cached Downloading: ../data/celeba/img_align_celeba.zip
Downloading...
From: https://drive.google.com/uc?id=1zmsC4yvw-e089uHXj5EdP0BSZ0AlDQRR
To: /its/home/tk324/.cache/gdown/tmpskg80txk/dl
1.44GB [00:19, 73.0MB/s]
Computing MD5: ../data/celeba/img_align_celeba.zip
MD5 matches: ../data/celeba/img_align_celeba.zip
Cached Downloading: ../data/celeba/list_attr_celeba.txt
Downloading...
From: https://drive.google.com/uc?id=1gxmFoeEPgF9sT65Wpo85AnHl3zsQ4NvS
To: /its/home/tk324/.cache/gdown/tmp3m1i9qkx/dl
26.7MB [00:00, 46.0MB/s]
Computing MD5: ../data/celeba/list_attr_celeba.txt
MD5 matches: ../data/celeba/list_attr_celeba.txt
Cached Downloading: ../data/celeba/list_eval_partition.txt
Downloading...
From: https://drive.google.com/uc?id=1ih_VMokoI774ErNWrb26lDeWlanUBpnX
To: /its/home/tk324/.cache/gdown/tmpenbqu3ie/dl
2.84MB [00:00, 41.9MB/s]
Computing MD5: ../data/celeba/list_eval_partition.txt
MD5 matches: ../data/celeba/list_eval_partition.txt
```

That is, 19 seconds to download it. (Tested on fear.)